### PR TITLE
customization of rtc accept command output

### DIFF
--- a/src/main/java/com/deluan/jenkins/plugins/rtc/JazzClient.java
+++ b/src/main/java/com/deluan/jenkins/plugins/rtc/JazzClient.java
@@ -154,11 +154,12 @@ public class JazzClient {
     /**
      * Call <tt>scm accept</tt> command.<p/>
      *
-     * @return all changeSets accepted, complete with affected paths and related work itens
+     * @return all changeSets accepted, complete with affected paths and related work items
      * @throws IOException
      * @throws InterruptedException
      */
     public List<JazzChangeSet> accept() throws IOException, InterruptedException {
+    	logger.fine("accept()");
         Map<String, JazzChangeSet> compareCmdResults = compare();
 
         if (!compareCmdResults.isEmpty()) {
@@ -174,6 +175,7 @@ public class JazzClient {
             }
         }
 
+    	logger.fine("accept() end");
         return new ArrayList<JazzChangeSet>(compareCmdResults.values());
     }
 
@@ -195,6 +197,7 @@ public class JazzClient {
         try {
             result = cmd.parse(in);
         } catch (Exception e) {
+        	logger.log(Level.SEVERE, "Error parsing command!", e);
             throw new IOException(e);
         } finally {
             in.close();

--- a/src/main/java/com/deluan/jenkins/plugins/rtc/JazzRepositoryBrowser.java
+++ b/src/main/java/com/deluan/jenkins/plugins/rtc/JazzRepositoryBrowser.java
@@ -39,7 +39,11 @@ public class JazzRepositoryBrowser extends RepositoryBrowser<JazzChangeSet> {
     // ${repositoryUrl}/resource/itemName/com.ibm.team.workitem.WorkItem/${alias}
     public URL getWorkItemLink(JazzChangeSet changeSet, String workItem) throws IOException {
         String[] parts = workItem.split(" ");
-        String url = getBaseUrlString(changeSet) + "/resource/itemName/com.ibm.team.workitem.WorkItem/" + parts[0];
+        String baseUrl = getBaseUrlString(changeSet);
+        if(baseUrl.endsWith("/")) {
+        	baseUrl = baseUrl.substring(0, baseUrl.length() -1);
+        }
+        String url = baseUrl + "/resource/itemName/com.ibm.team.workitem.WorkItem/" + parts[0];
         return new URL(url);
     }
 

--- a/src/main/java/com/deluan/jenkins/plugins/rtc/JazzSCM.java
+++ b/src/main/java/com/deluan/jenkins/plugins/rtc/JazzSCM.java
@@ -136,6 +136,7 @@ public class JazzSCM extends SCM {
         try {
             changes = client.accept();
         } catch (IOException e) {
+        	logger.log(Level.WARNING, "Error accepting...", e);
             return false;
         }
 

--- a/src/main/java/com/deluan/jenkins/plugins/rtc/commands/AcceptCommand.java
+++ b/src/main/java/com/deluan/jenkins/plugins/rtc/commands/AcceptCommand.java
@@ -1,7 +1,9 @@
 package com.deluan.jenkins.plugins.rtc.commands;
 
+import com.deluan.jenkins.plugins.rtc.JazzClient;
 import com.deluan.jenkins.plugins.rtc.JazzConfiguration;
 import com.deluan.jenkins.plugins.rtc.changelog.JazzChangeSet;
+import com.deluan.jenkins.plugins.rtc.commands.accept.AcceptCustomOutputParser;
 import com.deluan.jenkins.plugins.rtc.commands.accept.AcceptNewOutputParser;
 import com.deluan.jenkins.plugins.rtc.commands.accept.AcceptOldOutputParser;
 import com.deluan.jenkins.plugins.rtc.commands.accept.BaseAcceptOutputParser;
@@ -13,6 +15,10 @@ import java.text.ParseException;
 import java.util.Collection;
 import java.util.LinkedHashSet;
 import java.util.Map;
+import java.util.logging.Logger;
+import java.util.regex.Pattern;
+
+import org.springframework.util.StringUtils;
 
 /**
  * @author deluan
@@ -20,6 +26,20 @@ import java.util.Map;
 public class AcceptCommand extends AbstractCommand implements ParseableCommand<Map<String, JazzChangeSet>> {
 
     public static final String NEW_FORMAT_VERSION = "2.1.0";
+
+    private static final Logger logger = Logger.getLogger(AcceptCommand.class.getName());
+
+    /*
+     * Environment properties used for custom rtc command line client output parsing.
+     * Have to use following values in jenkins windows start bat file for RTC 3.1.100:
+     * set RTC_ACCEPT_OUT_PATTERN_STARTCHANGESET=^^\s{6}\((\d+)\)\s(.*)
+     * set RTC_ACCEPT_OUT_PATTERN_FILE=^^\s{10}---(.)-\s+(.*)
+     * set RTC_ACCEPT_OUT_PATTERN_WORKITEM=^^\s{10}\((\d+)\)+(.*)
+     */
+    public static final String RTC_ACCEPT_OUT_PATTERN_STARTCHANGESET = "RTC_ACCEPT_OUT_PATTERN_STARTCHANGESET";
+    public static final String RTC_ACCEPT_OUT_PATTERN_FILE = "RTC_ACCEPT_OUT_PATTERN_FILE";
+    public static final String RTC_ACCEPT_OUT_PATTERN_WORKITEM = "RTC_ACCEPT_OUT_PATTERN_WORKITEM";
+    
     private Collection<String> changeSets;
     private BaseAcceptOutputParser parser;
     protected boolean oldFormat = false;
@@ -28,7 +48,19 @@ public class AcceptCommand extends AbstractCommand implements ParseableCommand<M
         super(configurationProvider);
         this.changeSets = new LinkedHashSet<String>(changeSets);
         this.oldFormat = (version.compareTo(NEW_FORMAT_VERSION) < 0);
-        parser = (oldFormat) ? new AcceptOldOutputParser() : new AcceptNewOutputParser();
+        
+        String startChangesetPattern = System.getenv(RTC_ACCEPT_OUT_PATTERN_STARTCHANGESET);
+        String filePattern = System.getenv(RTC_ACCEPT_OUT_PATTERN_FILE);
+        String workItemPattern = System.getenv(RTC_ACCEPT_OUT_PATTERN_WORKITEM);
+        
+    	if(StringUtils.hasText(startChangesetPattern) && StringUtils.hasText(filePattern) && StringUtils.hasText(workItemPattern)) {
+        	logger.info("RTCOUT_* flags found, using AcceptCustomOutputParser('" + startChangesetPattern + "','" + filePattern + "','" + workItemPattern + "')");
+        	parser = new AcceptCustomOutputParser(startChangesetPattern, filePattern, workItemPattern);
+        }
+        else {
+        	logger.info("RTCOUT_* flags not found, oldFormat: " + oldFormat);
+        	parser = (oldFormat) ? new AcceptOldOutputParser() : new AcceptNewOutputParser();
+        }
     }
 
     public ArgumentListBuilder getArguments() {

--- a/src/main/java/com/deluan/jenkins/plugins/rtc/commands/accept/AcceptCustomOutputParser.java
+++ b/src/main/java/com/deluan/jenkins/plugins/rtc/commands/accept/AcceptCustomOutputParser.java
@@ -1,0 +1,24 @@
+package com.deluan.jenkins.plugins.rtc.commands.accept;
+
+/**
+ * Configurable with three environment variables:
+ * RTC_ACCEPT_OUT_PATTERN_STARTCHANGESET, RTC_ACCEPT_OUT_PATTERN_FILE and RTC_ACCEPT_OUT_PATTERN_WORKITEM.
+ * (proper values for RTC 3.1.100: "^\s{6}\((\d+)\)\s(.*)", "^\s{10}---(.)-\s+(.*)" and "^\s{10}\((\d+)\)+(.*)".
+ * 
+ * @author vvidovic
+ */
+public class AcceptCustomOutputParser extends BaseAcceptOutputParser {
+	public AcceptCustomOutputParser(String startChangesetPattern, String filePattern, String workItemPattern) {
+        super(startChangesetPattern, filePattern, workItemPattern);
+    }
+
+    @Override
+    protected String parseWorkItem(String string) {
+        return string;
+    }
+
+    @Override
+    protected String parseEditFlag(String string) {
+        return string;
+    }
+}

--- a/src/main/resources/com/deluan/jenkins/plugins/rtc/changelog/JazzChangeSetList/index.jelly
+++ b/src/main/resources/com/deluan/jenkins/plugins/rtc/changelog/JazzChangeSetList/index.jelly
@@ -40,7 +40,7 @@
             </j:forEach>
             <tr>
                 <td colspan="2" class="changeset">
-                    <b>${%Related Work Itens}</b>
+                    <b>${%Related Work Items}</b>
                 </td>
             </tr>
             <j:forEach var="item" items="${cs.workItems}">

--- a/src/test/java/com/deluan/jenkins/plugins/rtc/changelog/JazzChangeLogReaderTest.java
+++ b/src/test/java/com/deluan/jenkins/plugins/rtc/changelog/JazzChangeLogReaderTest.java
@@ -60,8 +60,8 @@ public class JazzChangeLogReaderTest {
         assertThat("User is incorrect", readChangeSet.getUser(), is(originalChangeSet.getUser()));
         assertThat("Email is incorrect", readChangeSet.getEmail(), is(originalChangeSet.getEmail()));
         assertThat("Comment is incorrect", readChangeSet.getMsg(), is(originalChangeSet.getMsg()));
-        assertThat("Number of itens in changeset is incorrect", readChangeSet.getItems().size(), is(2));
-        assertThat("Number of work itens in changeset is incorrect", readChangeSet.getWorkItems().size(), is(1));
+        assertThat("Number of items in changeset is incorrect", readChangeSet.getItems().size(), is(2));
+        assertThat("Number of work items in changeset is incorrect", readChangeSet.getWorkItems().size(), is(1));
 
         JazzChangeSet.Item item = readChangeSet.getItems().get(0);
         assertThat("Action is incorrect", item.getAction(), is("delete"));

--- a/src/test/java/com/deluan/jenkins/plugins/rtc/commands/AcceptCommandTest.java
+++ b/src/test/java/com/deluan/jenkins/plugins/rtc/commands/AcceptCommandTest.java
@@ -45,7 +45,7 @@ public class AcceptCommandTest extends BaseCommandTest {
 
         JazzChangeSet changeSet = result.get("1714");
         assertEquals("The number of files in the changesets was incorrect", 8, changeSet.getAffectedPaths().size());
-        assertEquals("The number of work itens in the changesets was incorrect", 2, changeSet.getWorkItems().size());
+        assertEquals("The number of work items in the changesets was incorrect", 2, changeSet.getWorkItems().size());
 
         JazzChangeSet.Item item = changeSet.getItems().get(0);
         assertTrue("The file is not the expected one", item.getPath().endsWith("GerenteOferta.java"));
@@ -66,7 +66,7 @@ public class AcceptCommandTest extends BaseCommandTest {
 
         JazzChangeSet changeSet = result.get("1020");
         assertEquals("The number of files in the changesets was incorrect", 2, changeSet.getAffectedPaths().size());
-        assertEquals("The number of work itens in the changesets was incorrect", 1, changeSet.getWorkItems().size());
+        assertEquals("The number of work items in the changesets was incorrect", 1, changeSet.getWorkItems().size());
 
         JazzChangeSet.Item item = changeSet.getItems().get(0);
         assertTrue("The file is not the expected one", item.getPath().endsWith("com_tps_eppic_ConfigValues_core_properties"));
@@ -83,7 +83,7 @@ public class AcceptCommandTest extends BaseCommandTest {
 
         JazzChangeSet changeSet = result.get("1002");
         assertEquals("The number of files in the changesets was incorrect", 5, changeSet.getAffectedPaths().size());
-        assertEquals("The number of work itens in the changesets was incorrect", 1, changeSet.getWorkItems().size());
+        assertEquals("The number of work items in the changesets was incorrect", 1, changeSet.getWorkItems().size());
 
         JazzChangeSet.Item item = changeSet.getItems().get(3);
         assertTrue("The file is not the expected one", item.getPath().endsWith("FabricaEJBBean.java"));

--- a/src/test/java/com/deluan/jenkins/plugins/rtc/commands/CommandTest.java
+++ b/src/test/java/com/deluan/jenkins/plugins/rtc/commands/CommandTest.java
@@ -50,7 +50,7 @@ public class CommandTest extends BaseCommandTest {
 
         JazzChangeSet changeSet = result.get("1714");
         assertEquals("The number of files in the changesets was incorrect", 8, changeSet.getAffectedPaths().size());
-        assertEquals("The number of work itens in the changesets was incorrect", 2, changeSet.getWorkItems().size());
+        assertEquals("The number of work items in the changesets was incorrect", 2, changeSet.getWorkItems().size());
 
         JazzChangeSet.Item item = changeSet.getItems().get(0);
         assertTrue("The file is not the expected one", item.getPath().endsWith("GerenteOferta.java"));

--- a/src/test/java/com/deluan/jenkins/plugins/rtc/commands/accept/AcceptCustomOutputParserTest.java
+++ b/src/test/java/com/deluan/jenkins/plugins/rtc/commands/accept/AcceptCustomOutputParserTest.java
@@ -1,0 +1,47 @@
+package com.deluan.jenkins.plugins.rtc.commands.accept;
+
+import static org.junit.Assert.*;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.StringReader;
+import java.text.ParseException;
+import java.util.Map;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.deluan.jenkins.plugins.rtc.changelog.JazzChangeSet;
+
+/**
+ * Test for {@link AcceptCustomOutputParser}.
+ * @author vvidovic
+ */
+public class AcceptCustomOutputParserTest {
+
+	public static final int RTCOUT_ACTIONFLAG_POSITION = 3;
+	public static final String RTCOUT_PATTERN_FILE = "^\\s{10}---(.)-\\s+(.*)";
+	public static final String RTCOUT_PATTERN_STARTCHANGESET = "^\\s{6}\\((\\d+)\\)\\s(.*)";
+	public static final String RTCOUT_PATTERN_WORKITEM = "^\\s{10}[^\\d\\s]+(\\d+)[^\\d]+(.*)";
+	
+	public static final String TEST_OUT = "Workspace: (1002) \"RTC-workspace\"\n" +
+"  Component: (1003) \"Stream MavenModule\"\n" +
+"    Change sets:\n" +
+"      (1159) ---$  \"jenkins test.\" 03-sij-2013 04:32 PM\n" +
+"        Changes:\n" +
+"          ---c- \\MOdule\\3-design\\use-case-realizations\\17-razno\\ucr-something.sequence-diagram\n" +
+"        Work items:\n" +
+"          (1134) 49781 \"Osposobiti CI okolinu\"";
+
+	@Test
+	public void testParse() throws ParseException, IOException {
+		AcceptCustomOutputParser parser = new AcceptCustomOutputParser(RTCOUT_PATTERN_STARTCHANGESET, RTCOUT_PATTERN_FILE, RTCOUT_PATTERN_WORKITEM);
+		
+		StringReader sr = new StringReader(TEST_OUT);
+		BufferedReader br = new BufferedReader(sr);
+		Map<String, JazzChangeSet> result = parser.parse(br);
+		
+		Assert.assertNotNull(result);
+	}
+
+}


### PR DESCRIPTION
Hello,

at work we use RTC version 3.1.100 and Jenkins RTC plugin didn't work well with it. Plugin failed after each accept because RCT accept command output was different from the expected one.

I see there are two parsers (old and new one) and I added the third one which is used in case user defines three custom environment variables:
RTC_ACCEPT_OUT_PATTERN_STARTCHANGESET
RTC_ACCEPT_OUT_PATTERN_FILE
RTC_ACCEPT_OUT_PATTERN_WORKITEM

When I start Jenkins I set this three variables to following values and now plugin works fine:
"^\s{6}((\d+))\s(._)", "^\s{10}---(.)-\s+(._)" and "^\s{10}((\d+))+(.*)"

This way there is no need to update plugin each time rtc accept output changes.

Also I fixed few minor spelling errors (changed "itens" to "items").

Could you please accept this changes to main rtc-plugin code?

Thanks,
Vedran
