### PR TITLE
Restore lost functionality

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.424</version><!-- which version of Jenkins is this plugin built against? -->
+    <version>1.424</version>
   </parent>
 
     <artifactId>rtc</artifactId>
@@ -84,6 +84,12 @@
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-core</artifactId>
             <version>1.3.RC2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>net.vidageek</groupId>
+            <artifactId>mirror</artifactId>
+            <version>1.6.1</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/com/deluan/jenkins/plugins/rtc/JazzClient.java
+++ b/src/main/java/com/deluan/jenkins/plugins/rtc/JazzClient.java
@@ -281,22 +281,8 @@ public class JazzClient
 	
 	****************************************************/
     private Map<String, JazzChangeSet> compare() throws IOException, InterruptedException {
- 		//output to console.
-		PrintStream output = listener.getLogger();
-		output.println("  RTC SCM - Jazz Client: Compare...");
-
         CompareCommand cmd = new CompareCommand(configuration);
-		cmd.setListener(listener);
-		
-		java.util.Map compareResult = null;
-		try {
-			compareResult = execute(cmd);
-		} catch (hudson.AbortException e) {
-			output.println("  RTC SCM - Jazz Client: Compare command detected AbortException");
-			compareResult = new java.util.HashMap();
-			compareResult.put("AbortException", null);
-		}
-		return compareResult;
+		return execute(cmd);
     }
 
 	private <T> T execute(ParseableCommand<T> cmd) throws IOException, InterruptedException {

--- a/src/main/java/com/deluan/jenkins/plugins/rtc/JazzConfiguration.java
+++ b/src/main/java/com/deluan/jenkins/plugins/rtc/JazzConfiguration.java
@@ -3,10 +3,15 @@ import hudson.FilePath;
 import hudson.model.*;
 import java.io.*;
 
+import org.apache.commons.lang.builder.EqualsBuilder;
+import org.apache.commons.lang.builder.HashCodeBuilder;
+
 /**
  * @author deluan
  */
-public class JazzConfiguration implements Cloneable {
+public final class JazzConfiguration {
+    /* package */ static final Long DEFAULT_TIMEOUT = 60L * 60; // in seconds
+    
     private String repositoryLocation;
     private String workspaceName;
     private String defaultWorkspaceName;
@@ -21,8 +26,46 @@ public class JazzConfiguration implements Cloneable {
     private String password;
 	private boolean useUpdate;
     private FilePath jobWorkspace;
+    private boolean useTimeout;
+    private Long timeoutValue;
+    
     TaskListener listener;
 
+    public JazzConfiguration() {      
+    }
+    
+    public JazzConfiguration(JazzConfiguration aJazzConfiguration) {
+        this.repositoryLocation = aJazzConfiguration.repositoryLocation;
+        this.workspaceName = aJazzConfiguration.workspaceName;
+        this.defaultWorkspaceName = aJazzConfiguration.defaultWorkspaceName;
+        this.commonWorkspaceUNC = aJazzConfiguration.commonWorkspaceUNC;
+        this.nodeName = aJazzConfiguration.nodeName;
+        this.jobName = aJazzConfiguration.jobName;
+        this.agentsUsingCommonWorkspace = aJazzConfiguration.agentsUsingCommonWorkspace;
+        this.build = aJazzConfiguration.build;
+        this.listener = aJazzConfiguration.listener;
+        
+        this.streamName = aJazzConfiguration.streamName;
+        this.loadRules = aJazzConfiguration.loadRules;
+        
+        this.username = aJazzConfiguration.username;
+        this.password = aJazzConfiguration.password;
+        this.jobWorkspace = aJazzConfiguration.jobWorkspace;
+        
+        this.useTimeout = aJazzConfiguration.useTimeout;
+        this.timeoutValue = aJazzConfiguration.timeoutValue;        
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return EqualsBuilder.reflectionEquals(this, obj);
+    }
+    
+    @Override
+    public int hashCode() {
+        return HashCodeBuilder.reflectionHashCode(this);
+    }
+    
     public String getRepositoryLocation() {
         return repositoryLocation;
     }
@@ -87,6 +130,14 @@ public class JazzConfiguration implements Cloneable {
         return jobWorkspace;
     }
 
+    public boolean isUseTimeout() {
+        return useTimeout;
+    }
+    
+    public Long getTimeoutValue() {
+        return timeoutValue;
+    }
+    
     public void setRepositoryLocation(String repositoryLocation) {
         this.repositoryLocation = repositoryLocation;
     }
@@ -153,27 +204,13 @@ public class JazzConfiguration implements Cloneable {
         this.jobWorkspace = jobWorkspace;
     }
 
-    @SuppressWarnings({"CloneDoesntDeclareCloneNotSupportedException", "CloneDoesntCallSuperClone"})
-    @Override
-    public JazzConfiguration clone() {
-        JazzConfiguration clone = new JazzConfiguration();
-
-        clone.repositoryLocation = this.repositoryLocation;
-        clone.workspaceName = this.workspaceName;
-        clone.defaultWorkspaceName = this.defaultWorkspaceName;
-        clone.commonWorkspaceUNC = this.commonWorkspaceUNC;
-        clone.nodeName = this.nodeName;
-        clone.jobName = this.jobName;
-        clone.agentsUsingCommonWorkspace = this.agentsUsingCommonWorkspace;
-        clone.streamName = this.streamName;
-        clone.loadRules = this.loadRules;
-        clone.username = this.username;
-        clone.password = this.password;
-        clone.jobWorkspace = this.jobWorkspace;
-
-        return clone;
+    public void setUseTimeout(boolean useTimeout) {
+        this.useTimeout = useTimeout;
     }
- 
+    
+    public void setTimeoutValue(Long timeoutValue) {
+        this.timeoutValue = timeoutValue;
+    }
  
 	public boolean isUsingSharedWorkspace() {
 		

--- a/src/main/java/com/deluan/jenkins/plugins/rtc/JazzSCM.java
+++ b/src/main/java/com/deluan/jenkins/plugins/rtc/JazzSCM.java
@@ -492,10 +492,12 @@ public class JazzSCM extends SCM {
 
         @Override
         public boolean configure(StaplerRequest req, JSONObject json) throws FormException {
-            jazzExecutable = Util.fixEmpty(req.getParameter("rtc.jazzExecutable").trim());
-			RTCServerURL = Util.fixEmpty(req.getParameter("rtc.RTCServerURL").trim());
-			RTCUserName = Util.fixEmpty(req.getParameter("rtc.RTCUserName").trim());
-			RTCPassword = Secret.fromString(Util.fixEmpty(req.getParameter("rtc.RTCPassword")).trim());
+            jazzExecutable = Util.fixEmptyAndTrim(req.getParameter("rtc.jazzExecutable"));
+            RTCServerURL = Util.fixEmptyAndTrim(req.getParameter("rtc.RTCServerURL"));
+            RTCUserName = Util.fixEmptyAndTrim(req.getParameter("rtc.RTCUserName"));
+            String pass = Util.fixEmptyAndTrim(req.getParameter("rtc.RTCPassword"));
+            RTCPassword = (pass == null) ? null : Secret.fromString(pass);
+            
             save();
             return true;
         }

--- a/src/main/java/com/deluan/jenkins/plugins/rtc/changelog/JazzChangeSet.java
+++ b/src/main/java/com/deluan/jenkins/plugins/rtc/changelog/JazzChangeSet.java
@@ -3,6 +3,9 @@ package com.deluan.jenkins.plugins.rtc.changelog;
 import hudson.model.User;
 import hudson.scm.ChangeLogSet;
 import hudson.scm.EditType;
+
+import org.apache.commons.lang.builder.EqualsBuilder;
+import org.apache.commons.lang.builder.HashCodeBuilder;
 import org.apache.commons.lang.builder.ToStringBuilder;
 import org.kohsuke.stapler.export.Exported;
 import org.kohsuke.stapler.export.ExportedBean;
@@ -160,33 +163,39 @@ public final class JazzChangeSet extends ChangeLogSet.Entry implements Comparabl
     }
 
     @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-
-        JazzChangeSet changeSet = (JazzChangeSet) o;
-
-        if (date != null ? !date.equals(changeSet.date) : changeSet.date != null) return false;
-        if (email != null ? !email.equals(changeSet.email) : changeSet.email != null) return false;
-        if (items != null ? !items.equals(changeSet.items) : changeSet.items != null) return false;
-        if (msg != null ? !msg.equals(changeSet.msg) : changeSet.msg != null) return false;
-        if (rev != null ? !rev.equals(changeSet.rev) : changeSet.rev != null) return false;
-        if (user != null ? !user.equals(changeSet.user) : changeSet.user != null) return false;
-        if (workItems != null ? !workItems.equals(changeSet.workItems) : changeSet.workItems != null) return false;
-
-        return true;
+    public boolean equals(Object obj) {
+        if (obj == null) {
+            return false;
+        }
+        if (obj == this) {
+            return true;
+        }
+        if (obj.getClass() != getClass()) {
+            return false;
+        }
+        JazzChangeSet rhs = (JazzChangeSet) obj;
+        return new EqualsBuilder()
+                .append(date, rhs.date)
+                .append(email, rhs.email)
+                .append(items, rhs.items)
+                .append(msg, rhs.msg)
+                .append(rev, rhs.rev)
+                .append(user, rhs.user)
+                .append(workItems, rhs.workItems)
+                .isEquals();
     }
 
     @Override
     public int hashCode() {
-        int result = user != null ? user.hashCode() : 0;
-        result = 31 * result + (email != null ? email.hashCode() : 0);
-        result = 31 * result + (date != null ? date.hashCode() : 0);
-        result = 31 * result + (rev != null ? rev.hashCode() : 0);
-        result = 31 * result + (msg != null ? msg.hashCode() : 0);
-        result = 31 * result + (items != null ? items.hashCode() : 0);
-        result = 31 * result + (workItems != null ? workItems.hashCode() : 0);
-        return result;
+        return new HashCodeBuilder(17, 37)
+                .append(date)
+                .append(email)
+                .append(items)
+                .append(msg)
+                .append(rev)
+                .append(user)
+                .append(workItems)
+                .toHashCode();
     }
 
     @ExportedBean(defaultVisibility = 999)
@@ -243,24 +252,29 @@ public final class JazzChangeSet extends ChangeLogSet.Entry implements Comparabl
         }
 
         @Override
-        public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
-
-            Item item = (Item) o;
-
-            if (action != null ? !action.equals(item.action) : item.action != null) return false;
-            //noinspection RedundantIfStatement
-            if (path != null ? !path.equals(item.path) : item.path != null) return false;
-
-            return true;
+        public boolean equals(Object obj) {
+            if (obj == null) {
+                return false;
+            }
+            if (obj == this) {
+                return true;
+            }
+            if (obj.getClass() != getClass()) {
+                return false;
+            }
+            Item rhs = (Item) obj;
+            return new EqualsBuilder()
+                    .append(path, rhs.path)
+                    .append(action, rhs.action)
+                    .isEquals();
         }
 
         @Override
         public int hashCode() {
-            int result = path != null ? path.hashCode() : 0;
-            result = 31 * result + (action != null ? action.hashCode() : 0);
-            return result;
+            return new HashCodeBuilder(17, 37).
+                    append(path).
+                    append(action).
+                    toHashCode();
         }
     }
 }

--- a/src/main/java/com/deluan/jenkins/plugins/rtc/changelog/JazzChangeSetList.java
+++ b/src/main/java/com/deluan/jenkins/plugins/rtc/changelog/JazzChangeSetList.java
@@ -17,8 +17,9 @@ public class JazzChangeSetList extends ChangeLogSet<JazzChangeSet> {
         super(build);
         Collections.reverse(logs);  // put new things first
         this.changeSets = Collections.unmodifiableList(logs);
-        for (JazzChangeSet log : logs)
+        for (JazzChangeSet log : logs) {
             log.setParent(this);
+        }
     }
 
     public boolean isEmptySet() {
@@ -34,9 +35,8 @@ public class JazzChangeSetList extends ChangeLogSet<JazzChangeSet> {
         return changeSets;
     }
 
-    public
     @Override
-    String getKind() {
+    public String getKind() {
         return "rtc";
     }
 

--- a/src/main/java/com/deluan/jenkins/plugins/rtc/commands/CompareCommand.java
+++ b/src/main/java/com/deluan/jenkins/plugins/rtc/commands/CompareCommand.java
@@ -107,7 +107,7 @@ public class CompareCommand extends AbstractCommand implements ParseableCommand<
     private String parseMessage(String string) {
         String msg = string.trim();
         if (msg.startsWith("\"")) {
-            int closingQuotes = msg.lastIndexOf("\"");
+            int closingQuotes = msg.lastIndexOf('\"');
             msg = msg.substring(1, closingQuotes).trim();
         }
         return msg;

--- a/src/main/java/com/deluan/jenkins/plugins/rtc/commands/CompareCommand.java
+++ b/src/main/java/com/deluan/jenkins/plugins/rtc/commands/CompareCommand.java
@@ -24,9 +24,7 @@ public class CompareCommand extends AbstractCommand implements ParseableCommand<
     private static final String DATE_FORMAT = "yyyy-MM-dd-HH:mm:ss";
     private static final String CONTRIBUTOR_FORMAT = "|{name}|{email}|";
     private final SimpleDateFormat sdf = new SimpleDateFormat(DATE_FORMAT);
-	
-	private TaskListener listener = null;
-	
+		
     public CompareCommand(JazzConfiguration configurationProvider) {
         super(configurationProvider);
     }
@@ -46,10 +44,6 @@ public class CompareCommand extends AbstractCommand implements ParseableCommand<
         return args;
     }
 	
-	public void setListener(TaskListener listener) {
-		this.listener = listener;
-	}
-
     public Map<String, JazzChangeSet> parse(BufferedReader reader) throws ParseException, IOException {
         Map<String, JazzChangeSet> result = new LinkedHashMap<String, JazzChangeSet>();
 		String loadRules = getConfig().getLoadRules();
@@ -100,7 +94,6 @@ public class CompareCommand extends AbstractCommand implements ParseableCommand<
 				}
             } catch (Exception e) {
                 logger.log(Level.WARNING, "Error parsing compare output:\n\n" + line + "\n\n", e);
-				listener.error("caught error " + e);
             }
         }
 

--- a/src/main/java/com/deluan/jenkins/plugins/rtc/commands/accept/BaseAcceptOutputParser.java
+++ b/src/main/java/com/deluan/jenkins/plugins/rtc/commands/accept/BaseAcceptOutputParser.java
@@ -14,7 +14,7 @@ import java.util.regex.Pattern;
 /**
  * @author deluan
  */
-abstract public class BaseAcceptOutputParser {
+public abstract class BaseAcceptOutputParser {
     protected Pattern startChangesetPattern;
     protected Pattern filePattern;
     protected Pattern workItemPattern;
@@ -57,9 +57,9 @@ abstract public class BaseAcceptOutputParser {
         return result;
     }
 
-    abstract protected String parseWorkItem(String string);
+    protected abstract String parseWorkItem(String string);
 
-    abstract protected String parseEditFlag(String string);
+    protected abstract String parseEditFlag(String string);
 
     protected String parsePath(String string) {
         String path = string.replaceAll("\\\\", "/").trim();

--- a/src/main/resources/com/deluan/jenkins/plugins/rtc/JazzSCM/config.jelly
+++ b/src/main/resources/com/deluan/jenkins/plugins/rtc/JazzSCM/config.jelly
@@ -37,4 +37,13 @@
 		description="If left blank, uses global value">
 		<f:password/>		
 	</f:entry>
+	
+	<f:advanced>
+		<f:entry title="${%Enable timeout}" field="useTimeout">
+			<f:checkbox />
+		</f:entry>
+    	<f:entry title="${%Timeout Value}" field="timeoutValue">
+			<f:textbox />
+    	</f:entry>
+	</f:advanced>	
 </j:jelly>

--- a/src/main/resources/com/deluan/jenkins/plugins/rtc/JazzSCM/help-timeoutValue.html
+++ b/src/main/resources/com/deluan/jenkins/plugins/rtc/JazzSCM/help-timeoutValue.html
@@ -1,0 +1,3 @@
+<div>
+Timeout value after which RTC commands will be aborted (in seconds).
+</div>

--- a/src/main/resources/com/deluan/jenkins/plugins/rtc/JazzSCM/help-useTimeout.html
+++ b/src/main/resources/com/deluan/jenkins/plugins/rtc/JazzSCM/help-useTimeout.html
@@ -1,0 +1,4 @@
+<div>
+Indicates if a timeout should be taken into account.  If checked, <i>timeoutValue</i>
+will be applied.
+</div>

--- a/src/test/java/com/deluan/jenkins/plugins/rtc/JazzConfigurationTest.java
+++ b/src/test/java/com/deluan/jenkins/plugins/rtc/JazzConfigurationTest.java
@@ -1,0 +1,96 @@
+package com.deluan.jenkins.plugins.rtc;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import hudson.EnvVars;
+import hudson.FilePath;
+import hudson.model.TaskListener;
+import hudson.model.AbstractBuild;
+import hudson.model.Node;
+
+import java.io.File;
+import java.lang.reflect.Field;
+import java.util.List;
+
+import net.vidageek.mirror.dsl.Mirror;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.gargoylesoftware.base.testing.EqualsTester;
+
+/**
+ * @author deluan
+ */
+public class JazzConfigurationTest {
+
+    JazzConfiguration configuration;
+
+    @Before
+    public void setUp() throws Exception {
+        configuration = createConfiguration();
+    }
+
+    @Test
+    public void testAllSettersCalled() throws Exception {
+        assertNoNullFields(configuration);
+    }
+
+    @Test
+    public void testClone() throws Exception {
+        JazzConfiguration clone = new JazzConfiguration(configuration);
+
+        assertThat(clone, equalTo(configuration));
+    }
+
+    @Test
+    public void testEqualsAndHash() {
+        final JazzConfiguration a = new JazzConfiguration(configuration);
+        final JazzConfiguration b = new JazzConfiguration(configuration); // another JazzChangeSet that has the same values as the original
+        final JazzConfiguration c = new JazzConfiguration(); // another JazzChangeSet with different values
+        new EqualsTester(a, b, c, null);
+    }
+
+    private void assertNoNullFields(JazzConfiguration clone) {
+        List<Field> fields = new Mirror().on(JazzConfiguration.class).reflectAll().fields();
+
+        for (Field field : fields) {
+            Object value = new Mirror().on(clone).get().field(field);
+            assertNotNull("Field " + field.getName() + " is null", value);
+        }
+    }
+
+    private JazzConfiguration createConfiguration() throws Exception {
+        JazzConfiguration configuration = new JazzConfiguration();
+
+        configuration.setRepositoryLocation("repo");
+        configuration.setWorkspaceName("workspace");
+        configuration.setStreamName("stream");
+        configuration.setUsername("user");
+        configuration.setPassword("password");
+        configuration.setJobWorkspace(new FilePath(new File("job")));
+                
+        AbstractBuild mockBuild = mock(AbstractBuild.class);
+        EnvVars mockEnv = mock(EnvVars.class);
+        TaskListener mockListener = mock(TaskListener.class);
+        Node mockNode = mock(Node.class);
+        when(mockBuild.getEnvironment(null)).thenReturn(mockEnv);
+        when(mockBuild.getBuiltOn()).thenReturn(mockNode);
+        configuration.setBuild(mockBuild);
+        configuration.setTaskListener(mockListener);
+        configuration.setDefaultWorkspaceName("wsn");
+        configuration.setCommonWorkspaceUNC("cwu");
+        configuration.setNodeName("nodename");
+        configuration.setJobName("jobname");
+        configuration.setAgentsUsingCommonWorkspace("aucw");
+
+        configuration.setLoadRules("loadRules");
+        
+        configuration.setUseTimeout(true);
+        configuration.setTimeoutValue(1L);
+        return configuration;
+    }
+}

--- a/src/test/java/com/deluan/jenkins/plugins/rtc/JazzRepositoryBrowserTest.java
+++ b/src/test/java/com/deluan/jenkins/plugins/rtc/JazzRepositoryBrowserTest.java
@@ -33,7 +33,7 @@ public class JazzRepositoryBrowserTest {
     public void setUp() {
         MockitoAnnotations.initMocks(this);
         when(build.getProject()).thenReturn(project);
-        when(project.getScm()).thenReturn(new JazzSCM(SERVER_URL, null, null, null, null, null, false));
+        when(project.getScm()).thenReturn(new JazzSCM(SERVER_URL, null, null, null, null, false, null, null, false));
     }
 
     @Test

--- a/src/test/java/com/deluan/jenkins/plugins/rtc/JazzSCMTest.java
+++ b/src/test/java/com/deluan/jenkins/plugins/rtc/JazzSCMTest.java
@@ -147,6 +147,8 @@ public class JazzSCMTest {
                 jobConfig.getStreamName(),
                 jobConfig.getUsername(),
                 jobConfig.getPassword(),
+                jobConfig.isUseTimeout(),
+                jobConfig.getTimeoutValue(),
                 jobConfig.getLoadRules(),
                 jobConfig.getUseUpdate());
         
@@ -161,9 +163,12 @@ public class JazzSCMTest {
         private DescriptorImpl descriptor;
 
         public JazzSCMWithCustomDescriptor(String repositoryLocation,
-                String workspaceName, String streamName, String username,
-                String password, String loadRules, boolean useUpdate) {
+                String workspaceName, String streamName,
+                String username, String password,
+                boolean useTimeout, Long timeoutValue,
+                String loadRules, boolean useUpdate) {
             super(repositoryLocation, workspaceName, streamName, username, password,
+                    useTimeout, timeoutValue,
                     loadRules, useUpdate);
         }
         

--- a/src/test/java/com/deluan/jenkins/plugins/rtc/changelog/JazzChangeSetTest.java
+++ b/src/test/java/com/deluan/jenkins/plugins/rtc/changelog/JazzChangeSetTest.java
@@ -171,11 +171,21 @@ public class JazzChangeSetTest {
     }
 
     @Test
-    public void testEqualsAndHash() {
+    public void testChangeSetEqualsAndHash() {
         Date date = new Date();
         final JazzChangeSet a = createChangeSet("1", date, "deluan", "email@a.com", "msg"); // original JazzChangeSet
         final JazzChangeSet b = createChangeSet("1", date, "deluan", "email@a.com", "msg"); // another JazzChangeSet that has the same values as the original
         final JazzChangeSet c = createChangeSet("2", date, "user", "user@a.com", "msg2");   // another JazzChangeSet with different values
         new EqualsTester(a, b, c, null);
+    }
+    
+    @Test
+    public void testItemsEqualsAndHash() {
+        final JazzChangeSet.Item a = new JazzChangeSet.Item("path", "action");
+        final JazzChangeSet.Item b = new JazzChangeSet.Item("path", "action"); // another JazzChangeSet that has the same values as the original
+        final JazzChangeSet.Item c = new JazzChangeSet.Item("path2", "action2"); // another JazzChangeSet with different values
+        final JazzChangeSet.Item d = new JazzChangeSet.Item("path", "action") {
+        };
+        new EqualsTester(a, b, c, d);
     }
 }


### PR DESCRIPTION
This patch restores various bits of functionality which were lost in a previous pull request.
- Restore timeouts
- Restore unit tests for JazzConfiguration, and a switch from Cloneable to a copy constructor that had also been lost
- Fix NPEs in config parsing
- Failed SCM polls no longer trigger builds off
